### PR TITLE
feat: update to store bytes and update emit Transfer

### DIFF
--- a/evm/test/membership.ts
+++ b/evm/test/membership.ts
@@ -48,7 +48,7 @@ describe('Membership', function () {
 
         const tokenDataResult = await membership.tokenData(1);
 
-        expect(tokenDataResult).to.be.equal(ipfsHash);
+        expect(tokenDataResult).to.be.equal(tokenData);
 
         const tokenOwnerResult = await membership.tokenOwner(1);
 
@@ -80,7 +80,7 @@ describe('Membership', function () {
 
         const tokenDataResult = await membership.tokenData(1);
 
-        expect(tokenDataResult).to.be.equal(updatedIpfsHash);
+        expect(tokenDataResult).to.be.equal(updatedTokenData);
       });
     });
 
@@ -104,7 +104,7 @@ describe('Membership', function () {
 
         const data = await membership.tokenData(1);
 
-        expect(data).to.be.equals('');
+        expect(data).to.be.equals('0x');
       });
     });
   });


### PR DESCRIPTION
Changed the stored value of `tokenData`.
Changed the accepted parameter in `constructor`.
Changed the arguments in Transfer for `mint` and `burn`.
Updated the tests